### PR TITLE
Update content/installing_nokogiri.md

### DIFF
--- a/content/installing_nokogiri.md
+++ b/content/installing_nokogiri.md
@@ -76,6 +76,9 @@ Then install libiconv from source:
     ./configure --prefix=/usr/local/Cellar/libiconv/1.13.1
     make
     sudo make install
+
+If using Mountain Lion with Homebrew 0.9, it's been [reported](https://github.com/sparklemotion/nokogiri/issues/442#issuecomment-7978408) that you may also need to use gcc 4.2:
+    sudo ln -s /usr/bin/gcc /usr/bin/gcc-4.2
     
 Then (finally) install nokogiri:
 


### PR DESCRIPTION
adding step to use gcc-4.2 when installing nokogiri with homebrew 0.9 and osx mountain lion, 
as reported by brax444 (https://github.com/sparklemotion/nokogiri/issues/442#issuecomment-7978408)

seems to have fixed things for me in my personal testing as well.
