### PR TITLE
Adds instructions for OSX Maveicks brew@0.9.5

### DIFF
--- a/content/installing_nokogiri.md
+++ b/content/installing_nokogiri.md
@@ -59,6 +59,27 @@ And if you have problems, try:
 
     sudo port upgrade outdated
 
+### homebrew 0.9.5
+
+Install homebrew.
+
+    brew doctor
+
+Fix anything mentioned in the `brew doctor` output.
+
+Install ruby using homebrew.
+
+    brew install ruby
+    echo 'export PATH=/usr/local/opt/ruby/bin:$PATH' >> ~/.bash_profile
+
+`source ~/.bash_profile` should reuslt in an updated path, but the brew installed `ruby` isn't found. The solution is to open a new terminal session.
+
+Install nokogiri
+
+    gem install nokogiri
+
+This is known to work on OSX Mavericks OS X 10.9.2 (13C1021).
+
 ### homebrew 0.9
 
 Apparently some people have had problems getting libiconv to install


### PR DESCRIPTION
None of the instructions on the tutorial or bug list correctly install on \na fresh OSX mavericks install. The added instructions work.
