### PR TITLE
Update Homebrew 0.9 tutorial

### DIFF
--- a/content/installing_nokogiri.md
+++ b/content/installing_nokogiri.md
@@ -65,8 +65,7 @@ Apparently some people have had problems getting libiconv to install
 under homebrew 0.9 (see [issue #442](https://github.com/sparklemotion/nokogiri/issues/442)).
 Here's what reportedly works:
 
-    brew install libxml2 libxslt
-    brew link libxml2 libxslt
+    brew install libxml2 libxslt wget
     
 Then install libiconv from source:
 


### PR DESCRIPTION
- `brew link` reports that it doesn't do anything in this scenario
- `wget` is not installed by default on Macs, so install it with homebrew just in case

@flavorjones Beach time pays off :)
