### PR TITLE
Add libgmp-dev dependency for Ubuntu 14.04.3

### DIFF
--- a/content/installing_nokogiri.md
+++ b/content/installing_nokogiri.md
@@ -40,7 +40,7 @@ authority that otherwise good and noble Ruby developers run into this.
 Here's what you should do if you should find yourself in this situation:
 
 ```sh
-sudo apt-get install ruby-dev zlib1g-dev
+sudo apt-get install ruby-dev zlib1g-dev libgmp-dev
 ```
 
 Please report it as a bug if this doesn't work for you (see


### PR DESCRIPTION
libgmp-dev need if you using Ubuntu 14.04.3.
If you using 14.04 only, nokogiri installation must be successful only with ruby-dev and zlib1g-dev.