### PR TITLE
Adds lines specifying that patch is a requirement for Ubuntu install.

### DIFF
--- a/content/installing_nokogiri.md
+++ b/content/installing_nokogiri.md
@@ -29,6 +29,14 @@ vendored `libxml2` and `libxslt`:
 gem install nokogiri
 ```
 
+This requires `patch` to be installed in order to work. It is very likely already
+installed as it is a common utility, but if you are using a VM or other
+system that doesn't have it installed, simply run:
+
+```sh
+sudo apt-get install patch
+```
+
 ### Troubleshooting Ubuntu / Debian Installation
 
 It's possible that you don't have important development header files


### PR DESCRIPTION
(It is required for the Just Works(tm) approach; it may not be necessary for
use-system-libraries approach, but it should be documented.)

This page is the top hit for "nokogiri install" and many other related phrases.  I didn't find the data that "patch" is a requirement anywhere.  It would have saved me at least 4 hours cumulative spent working around the problem by using system libraries.  :)