### PR TITLE
update installation instructions for OS X

### DIFF
--- a/content/installing_nokogiri.md
+++ b/content/installing_nokogiri.md
@@ -228,36 +228,20 @@ the package can be found [here](http://git.savannah.gnu.org/cgit/guix.git/tree/g
 
 ## Mac OS X
 
-Most developers are using homebrew to manage their packages these
-days. If you are, you're in luck.
-
-
-### homebrew 0.9.5+
-
-Installation should Just Work™ using Nokogiri's vendored `libxml2` and
-`libxslt`:
-
-```sh
-gem install nokogiri
-```
-
-However, you may need to jump through some hoops around `libiconv`
-... (see next section)
-
-
-### Troubleshooting OSX Installation
-
-#### "I'm on a fresh Yosemite installation."
-
-Team Nokogiri has reproduced an issue with brand-spanking-new Yosemite
-installations, which can be corrected by running:
+First, make sure you have the latest version of RubyGems:
 
 ```sh
 gem update --system
 ```
 
-Ya, really. >_< (Thanks to @zenspider for looking into this one.)
+Then install nokogiri:
 
+```sh
+gem install nokogiri
+```
+
+
+### Troubleshooting OSX Installation
 
 #### "I see error messages about libiconv."
 
@@ -293,7 +277,7 @@ This is verified working on OSX 10.9 w/ xcode's clang compiler.
 (Many thanks to @allaire and others for helping verify this!)
 
 
-### "But xcode-select is telling me about a 'network problem'."
+#### "But xcode-select is telling me about a 'network problem'."
 
 If, when you run the above commands, you see this dialog:
 


### PR DESCRIPTION
Addresses https://github.com/sparklemotion/nokogiri/issues/1509
- simplified the installation steps
- Having the latest version of RubyGems will solve most installation issues so that should be the first step
- Tidied up Troubleshooting OS X Installation section
