### PR TITLE
Fixed accessing unassigned variable "characters" in searching_a_xml_html_document.html

### DIFF
--- a/content/assets/search-xpath-characters-first.rb
+++ b/content/assets/search-xpath-characters-first.rb
@@ -1,4 +1,4 @@
 require 'search-setup'
-characters = @doc.xpath("//character")
 # :startdoc:
+characters = @doc.xpath("//character")
 characters[0].to_s # =>


### PR DESCRIPTION
In the `searching_a_xml_html_document.html`, the statement `@doc.xpath("//character")` was just executed without assigning to `characters`. And then, in the next code block, it references the unassigned `characters`. This PR fixes this inconsistency.
![screen shot 2018-04-09 at 8 00 53 am](https://user-images.githubusercontent.com/20811393/38473043-57bd3fbe-3bcc-11e8-8f6d-2c190f347e53.png)
